### PR TITLE
dots update: explicit play and repointable at any stack/app/space/secret

### DIFF
--- a/examples/web/dots/index.html
+++ b/examples/web/dots/index.html
@@ -13,7 +13,7 @@
   </head>
   <body>
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0" /> 
-    <div id="rooms">
+    <lobby id="6023060e-1668-483f-bd6f-e7ff707b8918">
       <p>Click on a room to speak with others there:</p>
 
       <room id="bcd48bdf-9a3b-4aec-9dd6-93b10d472318">

--- a/examples/web/dots/index.js
+++ b/examples/web/dots/index.js
@@ -275,6 +275,7 @@ class MyAvatar extends Avatar {
     connected(response) { // Connect the communicator output to the player.
         super.connected(response);
         player.srcObject = this.communicator.getOutputAudioMediaStream();
+        player.play(); // Some browsers ignore autoplay, even after user interaction.
         let subscription = new HighFidelityAudio.UserDataSubscription({
             "components": [
                 HighFidelityAudio.AvailableUserDataSubscriptionComponents.VolumeDecibels

--- a/examples/web/dots/style.css
+++ b/examples/web/dots/style.css
@@ -126,7 +126,7 @@ micControls:not(.muted) button.unmute,
     display: none;
 }
 
-room {
+lobby, room {
     display: block;
 }
 total, concurrency {


### PR DESCRIPTION
- I had removed the call to audio device play() in the last update, thinking it was unnecessary.  Bridie and Jess both had problems on Windows10/Chrome-latest, but no problems (in 1 of 1 test each).
- Make it practical to maintain two separate app ids for github pages hosting and codepen pages. It was hardcoded in the Javascript and was manually changing that javascript when pasting into codepen, which is error prone. Now I read the app id out of the index.html (which is necessarily different for codepen anyway because you only paste the body).
- Allow query parameter overrides for stack/appId/spaceId/secret, so that I can point it any dev/demo/test mixer and still have unique JWT per user.