### PR TITLE
Changing default mic orientation for spatial-microphone to be a default Euler orientation

### DIFF
--- a/experiments/nodejs/spatial-microphone/index.js
+++ b/experiments/nodejs/spatial-microphone/index.js
@@ -4,7 +4,7 @@ const express = require('express');
 const cors = require('cors');
 const crypto = require('crypto');
 const auth = require('./auth.json');
-const { Point3D, AudioAPIData, Communicator } = require("hifi-spatial-audio"); // Used to interface with the Spatial Audio API.
+const { OrientationEuler3D, Point3D, AudioAPIData, Communicator } = require("hifi-spatial-audio"); // Used to interface with the Spatial Audio API.
 const { RTCAudioSink } = require('wrtc').nonstandard;
 const Lame = require("node-lame").Lame;
 const wav = require('wav');
@@ -60,7 +60,8 @@ class SpatialMicrophone {
         this.spaceName = spaceName;
         // Define the initial HiFi Audio API Data used when connecting to the Spatial Audio API.
         this.audioAPIData = new AudioAPIData({
-            position: new Point3D(position)
+            position: new Point3D(position),
+            orientationEuler: new OrientationEuler3D()
         });
         // Set up the HiFiCommunicator used to communicate with the Spatial Audio API.
         this.communicator = new Communicator({ initialHiFiAudioAPIData: this.audioAPIData });


### PR DESCRIPTION
This matches what the spatial-speaker-space application uses. With the old behavior (nothing set as the mic's default orientation), spatial-speaker-space displays the mic facing in the wrong direction. This almost certainly means that there's something else wonky going on here (why would the default for a new OrientationEuler3D be different from the default default? Why would spatial-speaker-space see those two defaults differently? Is the bug in our OrientationEuler3D constructor, or in spatial-speaker-space? Etc.), but in the short term this fixes the basic issue, which is that the mic appears to be facing in the wrong direction in spatial-speaker-space.