### PR TITLE
fix --runtimeSeconds issues

### DIFF
--- a/examples/nodejs/testingbot/integration-test.js
+++ b/examples/nodejs/testingbot/integration-test.js
@@ -13,6 +13,7 @@ const defaults = {
     name: 'Bot #',
     serverShouldSendUserData: true,
     runtimeSeconds: 0,
+    shutdownSeconds: 0,
     measure: '',
     jwt: '',
     app_id: '', space_id: '', stackName: '',  // Edit in your own values here.
@@ -88,6 +89,11 @@ const argv = yargs
       .options('runtimeSeconds', {
           alias: 'r',
           describe: describe('How long should each bot run AFTER at it has completely started, or falsy to keep going indefinitely', 'runtimeSeconds'),
+          type: 'array'
+      })
+      .options('shutdownSeconds', {
+          alias: 'q',
+          describe: describe('How long should each bot run AFTER at it has disconnected, to allow for asynchronous statechange handlers to complete.', 'shutdownSeconds'),
           type: 'array'
       })
       .options('measure', {

--- a/examples/nodejs/testingbot/package.json
+++ b/examples/nodejs/testingbot/package.json
@@ -25,6 +25,7 @@
     "hifi-spatial-audio": "*",
     "jose": "^3.9.0",
     "make-fetch-happen": "^8.0.13",
+    "node-fetch": "^2.6.1",
     "pcm-convert": "^1.6.5",
     "wrtc": "^0.4.7",
     "yargs": "^16.2.0"


### PR DESCRIPTION
Two testingBots issues that only matter if you are specifying --runtimeSeconds to have the bots shut down after the specified runtime.)

1. Bots were not waiting around after shutdown, and so any code in an API/Ravi/RTC state-change handler wasn't getting the opportunity to fire. 

Now you can specify --shutdownSeconds (on command line or config) to wait after disconnect before the bot goes away.

2. If you have a timer that is moving bots around, updating position or orientation at some interval (such as the built-in random motion), that timer will keep firing as you are shutting down.  At some point, we changed the API internals to remove the current data holder just BEFORE shutdown, and there's no safety check for that in the API update code -- it just gives an error. It's arguable whether that is a bug in the API or the user code, but in any case, here I guard the user-code (i.e., the bot code).